### PR TITLE
German translation + changes to make dateAgo work with "locale"

### DIFF
--- a/_build/properties/dateago.php
+++ b/_build/properties/dateago.php
@@ -17,21 +17,21 @@ $properties = array(
 		'name' => 'dateFormat'
 		,'desc' => 'da_dateFormat'
 		,'type' => 'textfield'
-		,'value' => 'd F Y, H:i'
+		,'value' => '%a %e. %B %Y, %H:%M'
 		,'lexicon' => 'dateago:properties'
 	)
 	,array(
 		'name' => 'dateNow'
 		,'desc' => 'da_dateNow'
 		,'type' => 'numberfield'
-		,'value' => 10
+		,'value' => '59'
 		,'lexicon' => 'dateago:properties'
 	)
 	,array(
 		'name' => 'dateDay'
 		,'desc' => 'da_dateDay'
 		,'type' => 'textfield'
-		,'value' => 'day H:i'
+		,'value' => 'day %H:%M'
 		,'lexicon' => 'dateago:properties'
 	)
 	,array(
@@ -45,7 +45,7 @@ $properties = array(
 		'name' => 'dateHours'
 		,'desc' => 'da_dateHours'
 		,'type' => 'numberfield'
-		,'value' => '10'
+		,'value' => '12'
 		,'lexicon' => 'dateago:properties'
 	)
 

--- a/core/components/dateago/elements/snippets/dateago.php
+++ b/core/components/dateago/elements/snippets/dateago.php
@@ -18,7 +18,7 @@ $current = !empty($scriptProperties['current']) ? $scriptProperties['current'] :
 $delta = $current - $date;
 
 if ($scriptProperties['dateNow']) {
-	if ($delta < $scriptProperties['dateNow']) {return $modx->lexicon('da_now');}
+    if ($delta < $scriptProperties['dateNow']) {return $modx->lexicon('da_now');}
 }
 
 if ($scriptProperties['dateMinutes']) {
@@ -59,14 +59,9 @@ if ($scriptProperties['dateDay']) {
 		default: $day = null;
 	}
 	if($day) {
-		$format = str_replace("day",preg_replace("#(\w{1})#",'\\\${1}',$day),$scriptProperties['dateDay']);
-		return date($format,$date);
+		$format = str_replace('day',$day,$scriptProperties['dateDay']);
+		return strftime($format,$date);
 	}
 }
 
-$month_arr = $modx->fromJSON($modx->lexicon('da_months'));
-$m = date("n", $date);
-$month = $month_arr[$m - 1];
-
-$format = preg_replace("~(?<!\\\\)F~U",preg_replace('~(\w{1})~u','\\\${1}',$month),$dateFormat);
-return date($format ,$date);
+return strftime($dateFormat ,$date);

--- a/core/components/dateago/lexicon/de/default.inc.php
+++ b/core/components/dateago/lexicon/de/default.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Default German Lexicon Entries for dateAgo. By exside
+ *
+ * @package dateago
+ * @subpackage lexicon
+ */
+$_lang['da_now'] = 'gerade jetzt';
+$_lang['da_today'] = 'heute um';
+$_lang['da_yesterday'] = 'gestern um';
+$_lang['da_tomorrow'] = 'morgen um';
+$_lang['da_minutes'] = '["vor [[+minutes]] Minute","vor [[+minutes]] Minuten","vor [[+minutes]] Minuten"]';
+$_lang['da_minutes_less'] = 'vor weniger als einer Minute';
+$_lang['da_hours'] = '["vor [[+hours]] Stunde","vor [[+hours]] Stunden","vor [[+hours]] Stunden"]';
+$_lang['da_hours_less'] = 'vor weniger als einer Stunde';
+$_lang['da_months'] = '["Januar","Februar","März","April","Mai","Juni","Juli","August","September","Oktober","November","Dezember"]';

--- a/core/components/dateago/lexicon/de/properties.inc.php
+++ b/core/components/dateago/lexicon/de/properties.inc.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Properties German Lexicon Entries for dateAgo. By exside.
+ *
+ * @package dateago
+ * @subpackage lexicon
+ */
+$_lang['da_input'] = 'Standardmässig da übergebene Datum von publishedon, createdon etc., kann hier manuell gesetzt werden.';
+$_lang['da_dateFormat'] = 'Standard Datumsformat (Systemeinstellung "locale" richtig setzen!).';
+$_lang['da_dateDay'] = 'Dient dazu Angaben wie "Heute", "Gestern", "Morgen" zu ersetzen. "day" dient hier als Platzhalter und wird mit dem entsprechenden Lexikoneintrag ersetzt.';
+$_lang['da_dateNow'] = 'Anzahl Sekunden während Status "Gerade jetzt" angezeigt werden soll.';
+$_lang['da_dateMinutes'] = 'Anzahl Minuten während Status "vor ... Minuten" angezeigt werden soll.';
+$_lang['da_dateHours'] = 'Anzahl Stunden während Status "vor ... Stunden" angezeigt werden soll.';


### PR DESCRIPTION
Added german translation

I couldn't get dateAgo to work with the correct language specific
strings if a local is set via MODx system settings, had to change
several things, but now it seems to work. Don't know if you want to
implement the changes =), but if, here they are!

I'm also unsure about the declension function, does it have any purpose
out of russian language? What is it for anyway?
